### PR TITLE
fix: 删除页面无用的属性

### DIFF
--- a/src/templates/page-vue2.ts
+++ b/src/templates/page-vue2.ts
@@ -1,7 +1,5 @@
 const content = `\
-  name: "<%- options.name%>",
   components: {},
-  props: {},
   data() {
     return {}
   },


### PR DESCRIPTION
page页面不需要且也没有name和prop这两个属性